### PR TITLE
Document dependency on zsh

### DIFF
--- a/git-isclean
+++ b/git-isclean
@@ -23,6 +23,7 @@ Add this to your ~/.gitconfig:
 [alias]
     isclean = !/path/to/git-isclean
 
+(zsh must be installed first)
 Now you can run
 git isclean
 or 


### PR DESCRIPTION
I tried running this without zsh installed, but I got the unhelpful error message below. This adds a mention of zsh in the setup instructions.

```
david@desktop:~/git-isclean$ git isclean
error: cannot run /home/david/git-isclean/git-isclean: No such file or directory
fatal: While expanding alias 'isclean': '/home/david/git-isclean/git-isclean': No such file or directory
```
